### PR TITLE
Avoid non-initialized resize-sensor width/heights.

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -114,8 +114,8 @@
                     element.style.position = 'relative';
                 }
 
-                var x = 0,
-                    y = 0,
+                var x = -1,
+                    y = -1,
                     firstStyle = element.resizeSensor.firstElementChild.firstChild.style,
                     lastStyle = element.resizeSensor.lastElementChild.firstChild.style;
 


### PR DESCRIPTION
There is an issue when an element initially has zero width or height. The initialization does not set the resize-sensor-underflow to correctly pick up resize events in these cases. Additionally Firefox and Chrome seems to optimize away any underflow event to a div with no area.

The fix makes sure that the resize-sensors will get intializes correctly. It would be possible to initialize to 'null' instead, but then the comparisons afterwards needs to be a bit more strict.
