### PR TITLE
fix "TypeError: Illegal invocation" when using document.querySelectorAll

### DIFF
--- a/src/ElementQueries.js
+++ b/src/ElementQueries.js
@@ -148,9 +148,10 @@
          * @param {String} value
          */
         function queueQuery(selector, mode, property, value) {
-            var query = document.querySelectorAll;
-            if ('undefined' !== typeof $$) query = $$;
-            if ('undefined' !== typeof jQuery) query = jQuery;
+            var query;
+            if (document.querySelectorAll) query = document.querySelectorAll.bind(document);
+            if (!query && 'undefined' !== typeof $$) query = $$;
+            if (!query && 'undefined' !== typeof jQuery) query = jQuery;
 
             if (!query) {
                 throw 'No document.querySelectorAll, jQuery or Mootools\'s $$ found.';


### PR DESCRIPTION
I discovered a small bug when playing with ElementQueries.js.

Using ElementQueries.js without MooTools or jQuery produces `TypeError: Illegal invocation`. This is because `document.querySelectorAll` is aliased to a variable that is called without context.

More about this problem here: http://stackoverflow.com/questions/10743596/why-are-certain-function-calls-termed-illegal-invocations-in-javascript

This pull request fixes the problem.

jsFiddle that demonstrates the problem: http://jsfiddle.net/warpech/gDbM5/1/
jsFiddle with working fix: http://jsfiddle.net/warpech/gDbM5/5/

Screenshot of the problem in action (the first jsFiddle):

![screenshot 2014-04-02 14 25 17](https://cloud.githubusercontent.com/assets/566463/2590846/8c993cd6-ba63-11e3-80d1-b08a5efd3b31.png)

Thanks for your awesome work @marcj! I am playing with it and dreaming that one day this could become part of the CSS.
