### PR TITLE
Fixing IE8 JavaScript error

### DIFF
--- a/src/ElementQueries.js
+++ b/src/ElementQueries.js
@@ -154,7 +154,7 @@
          */
         function queueQuery(selector, mode, property, value) {
             var query;
-            if (document.querySelectorAll) query = document.querySelectorAll.bind(document);
+            if (document.querySelectorAll.bind) query = document.querySelectorAll.bind(document);
             if (!query && 'undefined' !== typeof $$) query = $$;
             if (!query && 'undefined' !== typeof jQuery) query = jQuery;
 


### PR DESCRIPTION
This request updates the querySelectorAll function detection to detect support for the bind function on that object.  This fixes #20.
