### PR TITLE
allow this to get around the Firefox SecurityError issues

### DIFF
--- a/src/ElementQueries.js
+++ b/src/ElementQueries.js
@@ -221,7 +221,9 @@
          */
         this.init = function() {
             for (var i = 0, j = document.styleSheets.length; i < j; i++) {
-                readRules(document.styleSheets[i].cssText || document.styleSheets[i].cssRules || document.styleSheets[i].rules);
+                if (document.styleSheets[i].href && document.styleSheets[i].href.indexOf(document.domain) >= 0) {
+                    readRules(document.styleSheets[i].cssText || document.styleSheets[i].cssRules || document.styleSheets[i].rules);
+                }
             }
         };
 


### PR DESCRIPTION
In reference to Issue #16: [External stylesheets won't work in Firefox: "SecurityError: The operation is insecure."](https://github.com/marcj/css-element-queries/issues/16)