### PR TITLE
Fix the External stylesheets error in Firefox

### DIFF
--- a/src/ElementQueries.js
+++ b/src/ElementQueries.js
@@ -232,7 +232,13 @@
         this.init = function(withTracking) {
             this.withTracking = withTracking;
             for (var i = 0, j = document.styleSheets.length; i < j; i++) {
-                readRules(document.styleSheets[i].cssText || document.styleSheets[i].cssRules || document.styleSheets[i].rules);
+                try {
+                    readRules(document.styleSheets[i].cssText || document.styleSheets[i].cssRules || document.styleSheets[i].rules);
+                } catch(e) {
+                    if (e.name !== 'SecurityError') {
+                        throw e;
+                    }
+                }
             }
         };
 


### PR DESCRIPTION
To circumvent the SecurityError in Firefox when attempting to access the cssRules attribute on external stylesheets, you must use a try/catch statement.

From: https://github.com/Turistforeningen/sherpa/commit/a8c9ac8358c96fa2097239425949e0f96f748daa