### PR TITLE
Add grunt and version bump task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,16 @@
+/* jshint node: true */
+module.exports = function(grunt) {
+  'use strict';
+
+  grunt.loadNpmTasks('grunt-bump');
+
+  grunt.initConfig({
+    bump: {
+      options: {
+        files: ['package.json', 'bower.json'],
+        commitFiles: ['package.json', 'bower.json'],
+        pushTo: 'origin'
+      }
+    }
+  });
+};

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "css-element-queries",
-  "version": "0.0.2",
+  "version": "0.2.0",
   "main": [
     "./src/ElementQueries.js",
     "./src/ResizeSensor.js"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "css-element-queries",
+  "version": "0.2.0",
+  "description": "CSS-Element-Queries Polyfill. proof-of-concept for high-speed element dimension/media queries in valid css.",
+  "main": "src/ElementQueries.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:marcj/css-element-queries.git"
+  },
+  "author": "Marc J. Schmidt",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/marcj/css-element-queries/issues"
+  },
+  "homepage": "https://github.com/marcj/css-element-queries",
+  "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-bump": "^0.3.1"
+  }
+}


### PR DESCRIPTION
Moin,

when this project is installed via bower, one gets the old version `0.0.2`. That is because the version number in `bower.json` is outdated. (See #50)

Here comes a fix to this along with a proposal to prevent such mismatches in the future.

With  [`grunt bump`](https://github.com/vojtajina/grunt-bump) the versions in `bower.json` and `package.json` are updated together, commited, a git tag is created and everything will be pushed to origin.
