### PR TITLE
Fix to properly add the tracked elements

### DIFF
--- a/src/ElementQueries.js
+++ b/src/ElementQueries.js
@@ -148,7 +148,7 @@
             }
             element.elementQueriesSetupInformation.call();
 
-            if (this.withTracking) {
+            if (ElementQueries.instance.withTracking && elements.indexOf(element) < 0) {
                 elements.push(element);
             }
         }


### PR DESCRIPTION
This is a fix to properly add the tracked elements to the elements array.  Previously, this.withTracking would end up referencing window instead of the ElementQueries instance.  The elements.indexOf(element) is to prevent adding duplicate elements.

Fixes #61