### PR TITLE
Fix a race condition where a rapid shrink and expand will cause neither to trigger a change

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -86,17 +86,28 @@
             var shrink = element.resizeSensor.childNodes[1];
             var shrinkChild = shrink.childNodes[0];
 
-            var lastWidth, lastHeight;
+            var lastShrinkWidth, lastShrinkHeight;
+            var lastExpandWidth, lastExpandHeight;
 
             var reset = function() {
+                resetExpand();
+                resetShrink();
+            };
+            
+            var resetExpand = function() {
                 expandChild.style.width = expand.offsetWidth + 10 + 'px';
                 expandChild.style.height = expand.offsetHeight + 10 + 'px';
                 expand.scrollLeft = expand.scrollWidth;
                 expand.scrollTop = expand.scrollHeight;
+                lastExpandWidth = element.offsetWidth;
+                lastExpandHeight = element.offsetHeight;
+            };
+            
+            var resetShrink = function() {
                 shrink.scrollLeft = shrink.scrollWidth;
                 shrink.scrollTop = shrink.scrollHeight;
-                lastWidth = element.offsetWidth;
-                lastHeight = element.offsetHeight;
+                lastShrinkWidth = element.offsetWidth;
+                lastShrinkHeight = element.offsetHeight;
             };
 
             reset();
@@ -116,17 +127,17 @@
             };
 
             addEvent(expand, 'scroll', function() {
-                if (element.offsetWidth > lastWidth || element.offsetHeight > lastHeight) {
+                if (element.offsetWidth > lastExpandWidth || element.offsetHeight > lastExpandHeight) {
                     changed();
                 }
-                reset();
+                resetExpand();
             });
 
             addEvent(shrink, 'scroll',function() {
-                if (element.offsetWidth < lastWidth || element.offsetHeight < lastHeight) {
+                if (element.offsetWidth < lastShrinkWidth || element.offsetHeight < lastShrinkHeight) {
                     changed();
                 }
-                reset();
+                resetShrink();
             });
         }
 


### PR DESCRIPTION
If a user manages to rapidly change both the shrink and expand, then the first one to fire may reset the last width and height causing the other scroll event to fail the change check, incorrectly. By keeping them on separate variables, we prevent this kind of exception.