### PR TITLE
Fix issue caused by not resetting both scrollbar positions

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -86,8 +86,7 @@
             var shrink = element.resizeSensor.childNodes[1];
             var shrinkChild = shrink.childNodes[0];
 
-            var lastShrinkWidth, lastShrinkHeight;
-            var lastExpandWidth, lastExpandHeight;
+            var lastWidth, lastHeight;
 
             var reset = function() {
                 expandChild.style.width = expand.offsetWidth + 10 + 'px';
@@ -96,6 +95,8 @@
                 expand.scrollTop = expand.scrollHeight;
                 shrink.scrollLeft = shrink.scrollWidth;
                 shrink.scrollTop = shrink.scrollHeight;
+                lastWidth = element.offsetWidth;
+                lastHeight = element.offsetHeight;
             };
 
             reset();
@@ -113,24 +114,16 @@
                     el.addEventListener(name, cb);
                 }
             };
+            
+            var onScroll = function() {
+              if (element.offsetWidth != lastWidth || element.offsetHeight != lastHeight) {
+                  changed();
+              }
+              reset();
+            }
 
-            addEvent(expand, 'scroll', function() {
-                if (element.offsetWidth > lastExpandWidth || element.offsetHeight > lastExpandHeight) {
-                    changed();
-                }
-                reset();
-                lastExpandWidth = element.offsetWidth;
-                lastExpandHeight = element.offsetHeight;
-            });
-
-            addEvent(shrink, 'scroll',function() {
-                if (element.offsetWidth < lastShrinkWidth || element.offsetHeight < lastShrinkHeight) {
-                    changed();
-                }
-                reset();
-                lastShrinkWidth = element.offsetWidth;
-                lastShrinkHeight = element.offsetHeight;
-            });
+            addEvent(expand, 'scroll', onScroll);
+            addEvent(shrink, 'scroll', onScroll);
         }
 
         if ("[object Array]" === Object.prototype.toString.call(element)

--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -90,24 +90,12 @@
             var lastExpandWidth, lastExpandHeight;
 
             var reset = function() {
-                resetExpand();
-                resetShrink();
-            };
-            
-            var resetExpand = function() {
                 expandChild.style.width = expand.offsetWidth + 10 + 'px';
                 expandChild.style.height = expand.offsetHeight + 10 + 'px';
                 expand.scrollLeft = expand.scrollWidth;
                 expand.scrollTop = expand.scrollHeight;
-                lastExpandWidth = element.offsetWidth;
-                lastExpandHeight = element.offsetHeight;
-            };
-            
-            var resetShrink = function() {
                 shrink.scrollLeft = shrink.scrollWidth;
                 shrink.scrollTop = shrink.scrollHeight;
-                lastShrinkWidth = element.offsetWidth;
-                lastShrinkHeight = element.offsetHeight;
             };
 
             reset();
@@ -130,14 +118,18 @@
                 if (element.offsetWidth > lastExpandWidth || element.offsetHeight > lastExpandHeight) {
                     changed();
                 }
-                resetExpand();
+                reset();
+                lastExpandWidth = element.offsetWidth;
+                lastExpandHeight = element.offsetHeight;
             });
 
             addEvent(shrink, 'scroll',function() {
                 if (element.offsetWidth < lastShrinkWidth || element.offsetHeight < lastShrinkHeight) {
                     changed();
                 }
-                resetShrink();
+                reset();
+                lastShrinkWidth = element.offsetWidth;
+                lastShrinkHeight = element.offsetHeight;
             });
         }
 


### PR DESCRIPTION
In my last PR, which was not thoroughly tested, I moved the expand and shrink scrollbar resets into separate methods. This was incorrect and caused expand/shrink in rapid succession failures in a different way. By reverting those changes and instead utilizing a != comparison, we have a simpler mechanism that considers that an expand and shrink could both occur before the event is triggered.