### PR TITLE
Fix bug when css rules are in peculiar order

### DIFF
--- a/src/ElementQueries.js
+++ b/src/ElementQueries.js
@@ -179,8 +179,8 @@
             }
         }
 
-        var regex = /,?([^,\n]*?)\[[\s\t]*?(min|max)-(width|height)[\s\t]*?[~$\^]?=[\s\t]*?"([^"]*?)"[\s\t]*?]([^\n\s\{]*?)/mgi;
-
+        var regex = /,?[\s\t]*([^,\n]*?)((?:\[[\s\t]*?(?:min|max)-(?:width|height)[\s\t]*?[~$\^]?=[\s\t]*?"[^"]*?"[\s\t]*?])+)([^,\n\s\{]*)/mgi;
+        var attrRegex = /\[[\s\t]*?(min|max)-(width|height)[\s\t]*?[~$\^]?=[\s\t]*?"([^"]*?)"[\s\t]*?]/mgi;
         /**
          * @param {String} css
          */
@@ -189,9 +189,11 @@
             var smatch;
             css = css.replace(/'/g, '"');
             while (null !== (match = regex.exec(css))) {
-                if (5 < match.length) {
-                    smatch = match[1] || match[5] || smatch;
-                    queueQuery(smatch, match[2], match[3], match[4]);
+                smatch = match[1] + match[3];
+                attrs = match[2];
+
+                while (null !== (attrMatch = attrRegex.exec(attrs))) {
+                    queueQuery(smatch, attrMatch[1], attrMatch[2], attrMatch[3]);
                 }
             }
         }
@@ -235,7 +237,7 @@
             this.withTracking = withTracking;
             for (var i = 0, j = document.styleSheets.length; i < j; i++) {
                 try {
-                    readRules(document.styleSheets[i].cssText || document.styleSheets[i].cssRules || document.styleSheets[i].rules);
+                    readRules(document.styleSheets[i].cssRules || document.styleSheets[i].rules || document.styleSheets[i].cssText);
                 } catch(e) {
                     if (e.name !== 'SecurityError') {
                         throw e;


### PR DESCRIPTION
One of my programmers fixed this, not me, so apologies for any inaccuracy in my explanation.

Some versions of IE will reorganize css selectors into a specific order for the cssRules styleSheet property.  The rewritten rule looks something like '[min-width~="400px"]div.myclassname'. This catches the elementqueries regex by surprise and failure occurs. Now, IE does this and it's weird, but it's perfectly valid CSS and any user could write CSS like this if they want to and you could reproduce the problem in Firefox or Chrome.

We fixed it up to hopefully cover all valid CSS cases. Once this is done, we found we could move the cssText property to the end of the list because we don't have a problem with what IE provides any more. This improves initial load performance in IE somewhat.

There is another pull request that directly conflicts with this. I didn't analyze the difference but we have been testing this thoroughly for two months in all browsers and it's solid.