### PR TITLE
Work with aggressive CSS transitions

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -65,7 +65,7 @@
             element.resizeSensor = document.createElement('div');
             element.resizeSensor.className = 'resize-sensor';
             var style = 'position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: hidden; z-index: -1; visibility: hidden;';
-            var styleChild = 'position: absolute; left: 0; top: 0;';
+            var styleChild = 'position: absolute; left: 0; top: 0; transition: 0s;';
 
             element.resizeSensor.style.cssText = style;
             element.resizeSensor.innerHTML =


### PR DESCRIPTION
Allow the sensor to work on very small elements (usually it needs to wait for some size to be reached, at least scrollbar width). Also, prevent 'expand' child from inheriting CSS transitions (which would possibily break the sensor by animating its size updates).