### PR TITLE
Fix #63 Use overflow: hidden instead of scroll

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -64,7 +64,7 @@
 
             element.resizeSensor = document.createElement('div');
             element.resizeSensor.className = 'resize-sensor';
-            var style = 'position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;';
+            var style = 'position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: hidden; z-index: -1; visibility: hidden;';
             var styleChild = 'position: absolute; left: 0; top: 0;';
 
             element.resizeSensor.style.cssText = style;
@@ -114,7 +114,7 @@
                     el.addEventListener(name, cb);
                 }
             };
-            
+
             var onScroll = function() {
               if (element.offsetWidth != lastWidth || element.offsetHeight != lastHeight) {
                   changed();


### PR DESCRIPTION
We had the same issue described in #63.

Before this commit:
![screen shot 2016-01-27 at 4 47 52 pm](https://cloud.githubusercontent.com/assets/1181237/12631564/97057a5c-c517-11e5-83d3-4539020d5260.png)

After:
![screen shot 2016-01-27 at 4 59 42 pm](https://cloud.githubusercontent.com/assets/1181237/12631568/99cf5078-c517-11e5-8d11-fc0c24e644b7.png)

Tested that the functionality was not changed (only errant scrollbars removed) in Safari 9, Chrome 48 and Firefox 41/43/44 on OS X.

Thanks for the great work on this!