### PR TITLE
Make resize sensor mostly transparent to CSS and JavaScript

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -69,9 +69,9 @@
                 return;
             }
 
-            element.resizeSensor = document.createElement('div');
+            element.resizeSensor = document.createElement('area');
             element.resizeSensor.className = 'resize-sensor';
-            var style = 'position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: hidden; z-index: -1; visibility: hidden;';
+            var style = 'display: block; position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: hidden; z-index: -1; visibility: hidden;';
             var styleChild = 'position: absolute; left: 0; top: 0; transition: 0s;';
 
             element.resizeSensor.style.cssText = style;

--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -72,7 +72,7 @@
             element.resizeSensor = document.createElement('area');
             element.resizeSensor.className = 'resize-sensor';
             var style = 'display: block; position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: hidden; z-index: -1; visibility: hidden;';
-            var styleChild = 'position: absolute; left: 0; top: 0; transition: 0s;';
+            var styleChild = 'position: absolute; left: 0; top: 0;';
 
             element.resizeSensor.style.cssText = style;
             element.resizeSensor.innerHTML =


### PR DESCRIPTION
Injecting such a common element as `<div>` into HTML could break rules like `:last-of-type` (both in CSS and JavaScript). Let's use an uncommon element - not used in layout design - such as `<area>` instead.

Meanwhile, revert a stale commit of mine.
