### PR TITLE
getEmSize had wrong Syntax for 'getComputedStyle'

### DIFF
--- a/src/ElementQueries.js
+++ b/src/ElementQueries.js
@@ -31,7 +31,7 @@
             if (!element) {
                 element = document.documentElement;
             }
-            var fontSize = getComputedStyle(element, 'fontSize');
+            var fontSize = window.getComputedStyle(element, null).fontSize;
             return parseFloat(fontSize) || 16;
         }
 
@@ -44,7 +44,8 @@
          * @returns {*}
          */
         function convertToPx(element, value) {
-            var units = value.replace(/[0-9]*/, '');
+            var numbers = value.split(/\d/);
+            var units = numbers[numbers.length-1];
             value = parseFloat(value);
             switch (units) {
                 case "px":


### PR DESCRIPTION
- The function getEmSize had a wrong Syntax for 'getComputedStyle',<br> the 2nd parameter is only for pseudo selectors and it will return all styles, see [docs](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle?redirectlocale=en-US&redirectslug=DOM%2Fwindow.getComputedStyle)

- The function convertToPx did not work for floats, I guess ...<br> E.g. `1.8rem`'s units became '.8rem' and so the switch failed...

Corrected both...