### PR TITLE
firefox requires 'scroll' to be set

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -110,7 +110,7 @@
 
             element.resizeSensor = document.createElement('div');
             element.resizeSensor.className = 'resize-sensor';
-            var style = 'position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: hidden; z-index: -1; visibility: hidden;';
+            var style = 'position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;';
             var styleChild = 'position: absolute; left: 0; top: 0; transition: 0s;';
 
             element.resizeSensor.style.cssText = style;


### PR DESCRIPTION
..otherwise setting scrollTop and scrollLeft does nothing (this is firefox 40.0.3), and thus resize detection does not work.

This is hinted at in the MDN page for scrollTop at https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop

specifically the line:

"When an element content does not generate a vertical scrollbar, then its scrollTop value defaults to 0."

setting overflow:scroll doesn't seem to have any adverse effect in my tests so far, though might have some impact on very tiny elements! a solution might be to also set top/left/bottom/right (or one or 2 of those) to negative values, so that there is always room for a scroll bar to exist. I haven't made this tweak.