### PR TITLE
Handle display:none gracefully on element or its parents

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -41,58 +41,165 @@
     }
 
     /**
+     * Class for adding/removing/triggering events.
+     *
+     * @constructor
+     */
+    function EventQueue() {
+        var q = [];
+        this.add = function(ev) {
+            q.push(ev);
+        };
+
+        var i, j;
+        this.call = function() {
+            for (i = 0, j = q.length; i < j; i++) {
+                q[i].call();
+            }
+        };
+
+        this.remove = function(ev) {
+            var newQueue = [];
+            for(i = 0, j = q.length; i < j; i++) {
+                if(q[i] !== ev) newQueue.push(q[i]);
+            }
+            q = newQueue;
+        }
+
+        this.length = function() {
+            return q.length;
+        }
+    }
+
+    /**
+     * @param {HTMLElement} element
+     * @param {String}      prop
+     * @returns {String|Number}
+     */
+    function getComputedStyle(element, prop) {
+        if (element.currentStyle) {
+            return element.currentStyle[prop];
+        } else if (window.getComputedStyle) {
+            return window.getComputedStyle(element, null).getPropertyValue(prop);
+        } else {
+            return element.style[prop];
+        }
+    }
+
+    /**
+     * checks "display" peoperty of elements relevant to
+     * the one provided and fires the provided callback
+     * once we are ready to start monitoring for resize
+     * events.
+     *
+     * @param   {HTMLElement} element
+     * @param   {Function}    callback
+     * @returns {Function}
+     */
+    var whenElementIsReady = (function(){
+
+        var interval = false;
+        var elsToMonitor = [];
+        var cbs = new EventQueue();
+
+        var checkDisplayProps = function(){
+            if(!elsToMonitor.length){
+                clearInterval(interval);
+                interval = false;
+                return;
+            }
+            for(var i = 0; i < elsToMonitor.length; i++){
+                var el = elsToMonitor[i];
+                el.__displayMonitor.display =
+                    window.getComputedStyle(el).display == "none" ? false : true;
+            }
+            cbs.call();
+        }
+
+        var getParents = function(el){
+            var els = [el];
+            while((el = el.parentNode) && el.nodeType === document.ELEMENT_NODE){
+                els.push(el);
+            }
+            return els;
+        }
+
+        var monitorThese = function(els){
+            for(var i = 0; i < els.length; i++){
+                var monitorObj = els[i].__displayMonitor
+                              || (els[i].__displayMonitor = {count: 0, display: false});
+                monitorObj.count++;
+                if(elsToMonitor.indexOf(els[i]) == -1) elsToMonitor.push(els[i]);
+            }
+        }
+
+        var stopMonitoringThese = function(els){
+            for(var i = 0; i < els.length; i++){
+                var monitorObj = els[i].__displayMonitor;
+                var count = monitorObj? --monitorObj.count : 0;
+                if(!count){
+                    delete els[i].__displayMonitor;
+                    elsToMonitor.splice(elsToMonitor.indexOf(els[i]), 1);
+                }
+            }
+        }
+
+        return function(element, callback, useInterval){
+
+            //no browser support? don't do.
+            if(!("getComputedStyle" in window)){
+                callback();
+                return function(){}
+            }
+
+            var allEls = getParents(element);
+            var isMonitoring = true;
+            monitorThese(allEls);
+
+            var stopMonitoringThis = function(){
+                isMonitoring = false;
+                stopMonitoringThese(allEls);
+                cbs.remove(monitorCb);
+            }
+
+            var monitorCb = function(){
+                for(var i = 0; i < allEls.length; i++){
+                    var el = allEls[i];
+                    if(!el.__displayMonitor.display) return;
+                }
+                stopMonitoringThis();
+                callback();
+            }
+
+            cbs.add(monitorCb);
+
+            if(useInterval && !interval){
+                interval = window.setInterval(checkDisplayProps, 150);
+            }
+
+            return {
+                stop: function(){
+                    if (isMonitoring) stopMonitoringThis();
+                },
+                triggerCheck: function(){
+                    if (isMonitoring) checkDisplayProps();
+                }
+            };
+
+        }
+
+    }());
+
+    /**
      * Class for dimension change detection.
      *
      * @param {Element|Element[]|Elements|jQuery} element
      * @param {Function} callback
+     * @param {Bool}     useIntervalCheck
      *
      * @constructor
      */
-    var ResizeSensor = function(element, callback) {
-        /**
-         *
-         * @constructor
-         */
-        function EventQueue() {
-            var q = [];
-            this.add = function(ev) {
-                q.push(ev);
-            };
-
-            var i, j;
-            this.call = function() {
-                for (i = 0, j = q.length; i < j; i++) {
-                    q[i].call();
-                }
-            };
-
-            this.remove = function(ev) {
-                var newQueue = [];
-                for(i = 0, j = q.length; i < j; i++) {
-                    if(q[i] !== ev) newQueue.push(q[i]);
-                }
-                q = newQueue;
-            }
-
-            this.length = function() {
-                return q.length;
-            }
-        }
-
-        /**
-         * @param {HTMLElement} element
-         * @param {String}      prop
-         * @returns {String|Number}
-         */
-        function getComputedStyle(element, prop) {
-            if (element.currentStyle) {
-                return element.currentStyle[prop];
-            } else if (window.getComputedStyle) {
-                return window.getComputedStyle(element, null).getPropertyValue(prop);
-            } else {
-                return element.style[prop];
-            }
-        }
+    var ResizeSensor = function(element, callback, useIntervalCheck) {
 
         /**
          *
@@ -100,6 +207,7 @@
          * @param {Function}    resized
          */
         function attachResizeEvent(element, resized) {
+
             if (!element.resizedAttached) {
                 element.resizedAttached = new EventQueue();
                 element.resizedAttached.add(resized);
@@ -110,7 +218,7 @@
 
             element.resizeSensor = document.createElement('div');
             element.resizeSensor.className = 'resize-sensor';
-            var style = 'position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;';
+            var style = 'position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: hidden; z-index: -1; visibility: hidden;';
             var styleChild = 'position: absolute; left: 0; top: 0; transition: 0s;';
 
             element.resizeSensor.style.cssText = style;
@@ -178,6 +286,7 @@
                 }
             };
 
+            element.resizeIsReady = whenElementIsReady(element, reset, useIntervalCheck);
             addEvent(expand, 'scroll', onScroll);
             addEvent(shrink, 'scroll', onScroll);
         }
@@ -189,6 +298,19 @@
         this.detach = function(ev) {
             ResizeSensor.detach(element, ev);
         };
+
+        // this checks whether the element is ready to be
+        // monitored for resize events yet or not. If you
+        // have asked for the checknot to occur on an interval,
+        // this is your alternate option for doing so.
+        this.checkDisplayProps = function(ev) {
+            forEachElement(element, function(elem){
+                if (elem.resizeIsReady) {
+                    elem.resizeIsReady.triggerCheck();
+                }
+            });
+        }
+
     };
 
     ResizeSensor.detach = function(element, ev) {
@@ -199,8 +321,12 @@
             }
             if (elem.resizeSensor) {
                 elem.removeChild(elem.resizeSensor);
+                if (elem.resizeIsReady){
+                    elem.resizeIsReady.stop();
+                }
                 delete elem.resizeSensor;
                 delete elem.resizedAttached;
+                delete elem.resizeIsReady;
             }
         });
     };

--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -110,7 +110,7 @@
 
             element.resizeSensor = document.createElement('div');
             element.resizeSensor.className = 'resize-sensor';
-            var style = 'position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: hidden; z-index: -1; visibility: hidden;';
+            var style = 'position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;';
             var styleChild = 'position: absolute; left: 0; top: 0; transition: 0s;';
 
             element.resizeSensor.style.cssText = style;


### PR DESCRIPTION
This commit adds checking to the element and its parents in which elements-to-be-checked are queued and their computed display properties checked under a single interval loop, which will trigger a reset() call to the resize handlers when the first instance of no display:nones becomes true.

I moved some code about to make this easier (reused the EventQueue), and made this interval checking optional, so it will only be used if you ask for it. Otherwise, a hook is provided so that you an manually run the check; this can be tied in with eg Angulars $digest mechanism
