### PR TITLE
When detaching, check that node is still a child before attempting to…

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -206,7 +206,9 @@
                 if(elem.resizedAttached.length()) return;
             }
             if (elem.resizeSensor) {
-                elem.removeChild(elem.resizeSensor);
+                if (elem.contains(elem.resizeSensor)) {
+                    elem.removeChild(elem.resizeSensor);
+                }
                 delete elem.resizeSensor;
                 delete elem.resizedAttached;
             }


### PR DESCRIPTION
… remove it.

Background: in my case, the main reason for detaching a listener is because the element has been disrupted (e.g. by having its innerHtml set to "" and being placed in a different parent element) which causes the listener to stop working. In this situation I want to re-register the listener. Before I am able succesfully to do so, I must detach the old listener. But the disruption has already removed the resizeSensor from the element. So when line removeChild throws a "Uncaught NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.". The line I have introduced prevents this in my copy (0.3.2).