### PR TITLE
Removed dirty checking, minor optimizations

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -142,12 +142,6 @@
             var lastWidth = element.offsetWidth;
             var lastHeight = element.offsetHeight;
 
-            var updateSize = function() {
-                dirty = false;
-                lastWidth = newWidth;
-                lastHeight = newHeight;
-            };
-
             var reset = function() {
                 expandChild.style.width = '100000px';
                 expandChild.style.height = '100000px';
@@ -164,10 +158,12 @@
             var onResized = function() {
                 rafId = 0;
 
-                if (!element.resizedAttached) return;
+                if (!dirty) return;
 
-                if (dirty) {
-                    updateSize();
+                lastWidth = newWidth;
+                lastHeight = newHeight;
+
+                if (element.resizedAttached) {
                     element.resizedAttached.call();
                 }
             };

--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -174,10 +174,15 @@
 
             var onResized = function() {
                 // To prevent layout thrashing: first read from DOM ...
-                if (!updateSize() || !element.resizedAttached) return;
+                var updated = updateSize();
+
+                if (!element.resizedAttached) return;
 
                 /// ... then update.
-                element.resizedAttached.call();
+                if (updated) {
+                    element.resizedAttached.call();
+                }
+
                 reset();
             };
 

--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -141,9 +141,20 @@
             var dirty, lastWidth, lastHeight;
 
             var updateSize = function() {
+                var newWidth = element.offsetWidth;
+                var newHeight = element.offsetHeight;
+
                 dirty = false;
-                lastWidth = element.offsetWidth;
-                lastHeight = element.offsetHeight;
+
+                // The size may stay the same if the element changed size more than once during one frame.
+                if (newWidth == lastWidth && newHeight == lastHeight) {
+                    return false;
+                }
+
+                lastWidth = newWidth;
+                lastHeight = newHeight;
+
+                return true;
             };
 
             updateSize();
@@ -163,11 +174,9 @@
 
             var onResized = function() {
                 // To prevent layout thrashing: first read from DOM ...
-                updateSize();
+                if (!updateSize() || !element.resizedAttached) return;
 
-                if (!element.resizedAttached) return;
-
-                /// ... then update
+                /// ... then update.
                 element.resizedAttached.call();
                 reset();
             };

--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -138,15 +138,15 @@
             var expand = element.resizeSensor.childNodes[0];
             var expandChild = expand.childNodes[0];
             var shrink = element.resizeSensor.childNodes[1];
-            var dirty, rafId, lastWidth, lastHeight, newWidth, newHeight;
+            var dirty, rafId, newWidth, newHeight;
+            var lastWidth = element.offsetWidth;
+            var lastHeight = element.offsetHeight;
 
             var updateSize = function() {
                 dirty = false;
                 lastWidth = newWidth;
                 lastHeight = newHeight;
             };
-
-            updateSize();
 
             var reset = function() {
                 expandChild.style.width = '100000px';


### PR DESCRIPTION
An update will now only be queued through requestAnimationFrame whenever
changes occurred. This means that absolutely no code is running when the
page is idling (helpful for power saving and scalability). Care was
taken to first read from the DOM and afterwards update it in the new
scroll handler to prevent any possible layout thrashing as described here:

http://wilsonpage.co.uk/preventing-layout-thrashing/

lastWidth, lastHeight and all sensor properties are only updated
once every frame.