### PR TITLE
Use 'window' if available as 'root' in exporting

### DIFF
--- a/src/ElementQueries.js
+++ b/src/ElementQueries.js
@@ -12,7 +12,7 @@
     } else {
         root.ElementQueries = factory(root.ResizeSensor);
     }
-}(this, function (ResizeSensor) {
+}(typeof window !== 'undefined' ? window : this, function (ResizeSensor) {
 
     /**
      *

--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -12,7 +12,7 @@
     } else {
         root.ResizeSensor = factory();
     }
-}(this, function () {
+}(typeof window !== 'undefined' ? window : this, function () {
 
     // Make sure it does not throw in a SSR (Server Side Rendering) situation
     if (typeof window === "undefined") {


### PR DESCRIPTION
We use css-element-queries (actually only the ResizeSensor) in a Polymer based app. While we were able to use ResizeSensor in the dev environment, we weren't able to use it in the built artifact created by gulp and Polymer CLI.
The problem was that 'root' was undefined in the exporting part of the ResizeSensor. I accordingly changed ElementQueries.js, but didn't test the change.