### PR TITLE
Fix getComputedStyle for firefox #148

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -85,7 +85,7 @@
                     if(q[i] !== ev) newQueue.push(q[i]);
                 }
                 q = newQueue;
-            }
+            };
 
             this.length = function() {
                 return q.length;
@@ -101,7 +101,7 @@
             if (element.currentStyle) {
                 return element.currentStyle[prop];
             }
-            if (window.getComputedStyle) {
+            if (window.getComputedStyle && window.getComputedStyle(element, null)) {
                 return window.getComputedStyle(element, null).getPropertyValue(prop);
             }
 

--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -105,12 +105,10 @@
             }
             
             if (window.getComputedStyle) {
-                try {
-                    computedElementStyle = window.getComputedStyle(element, null);
-                    if (computedElementStyle) {
-                        return computedElementStyle.getPropertyValue(prop);
-                    }
-                } catch(e) {}
+                computedElementStyle = window.getComputedStyle(element, null);
+                if (computedElementStyle) {
+                    return computedElementStyle.getPropertyValue(prop);
+                }
             }
 
             return element.style[prop];

--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -104,9 +104,13 @@
                 return element.currentStyle[prop];
             }
             
-            computedElementStyle = window.getComputedStyle(element, null);
-            if (window.getComputedStyle && computedElementStyle) {
-                return computedElementStyle.getPropertyValue(prop);
+            if (window.getComputedStyle) {
+                try {
+                    computedElementStyle = window.getComputedStyle(element, null);
+                    if (computedElementStyle) {
+                        return computedElementStyle.getPropertyValue(prop);
+                    }
+                } catch(e) {}
             }
 
             return element.style[prop];

--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -98,11 +98,15 @@
          * @returns {String|Number}
          */
         function getComputedStyle(element, prop) {
+            var computedElementStyle;
+            
             if (element.currentStyle) {
                 return element.currentStyle[prop];
             }
-            if (window.getComputedStyle && window.getComputedStyle(element, null)) {
-                return window.getComputedStyle(element, null).getPropertyValue(prop);
+            
+            computedElementStyle = window.getComputedStyle(element, null);
+            if (window.getComputedStyle && computedElementStyle) {
+                return computedElementStyle.getPropertyValue(prop);
             }
 
             return element.style[prop];


### PR DESCRIPTION
getComputedStyle can return null in Firefox in an iframe, see
https://github.com/marcj/css-element-queries/issues/148