### PR TITLE
Fix ElementQueries always attaching to window and listening

### DIFF
--- a/src/ElementQueries.js
+++ b/src/ElementQueries.js
@@ -11,6 +11,7 @@
         module.exports = factory(require('./ResizeSensor.js'));
     } else {
         root.ElementQueries = factory(root.ResizeSensor);
+        root.ElementQueries.listen();
     }
 }(this, function (ResizeSensor) {
 
@@ -500,15 +501,6 @@
     ElementQueries.listen = function() {
         domLoaded(ElementQueries.init);
     };
-
-    // make available to common module loader
-    if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
-        module.exports = ElementQueries;
-    }
-    else {
-        window.ElementQueries = ElementQueries;
-        ElementQueries.listen();
-    }
 
     return ElementQueries;
 


### PR DESCRIPTION
When we originally added UMD support, we forgot to move the logic that forcibly calls .listen() out of the block at the bottom and into the UMD logic block. This, in turn, meant that EQ was always being attached to window and listen was always being called, even when using EQ or ResizeSensor in a front-end environment with module support.