### PR TITLE
Fix sometimes element already unmount

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -114,6 +114,7 @@
          * @param {Function}    resized
          */
         function attachResizeEvent(element, resized) {
+            if (!element) return;
             if (element.resizedAttached) {
                 element.resizedAttached.add(resized);
                 return;
@@ -209,6 +210,7 @@
 
     ResizeSensor.detach = function(element, ev) {
         forEachElement(element, function(elem){
+            if (!elem) return
             if(elem.resizedAttached && typeof ev == "function"){
                 elem.resizedAttached.remove(ev);
                 if(elem.resizedAttached.length()) return;


### PR DESCRIPTION
When using with React, sometimes element already unmount and get error on `elem. resizedAttached`