### PR TITLE
Fixed bug that prevented detach from being called on instance

### DIFF
--- a/src/ElementQueries.js
+++ b/src/ElementQueries.js
@@ -415,7 +415,7 @@
         };
 
         this.detach = function() {
-            if (!this.withTracking) {
+            if (!trackingActive) {
                 throw 'withTracking is not enabled. We can not detach elements since we don not store it.' +
                 'Use ElementQueries.withTracking = true; before domready or call ElementQueryes.update(true).';
             }


### PR DESCRIPTION
Detach method on instance is checking for this.withTracking, when it should be checking for trackingActive as defined in the init function. this.withTracking is out of scope in the instance detach method.