### PR TITLE
ResizeSensor.js optimization

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -93,22 +93,6 @@
         }
 
         /**
-         * @param {HTMLElement} element
-         * @param {String}      prop
-         * @returns {String|Number}
-         */
-        function getComputedStyle(element, prop) {
-            if (element.currentStyle) {
-                return element.currentStyle[prop];
-            }
-            if (window.getComputedStyle) {
-                return window.getComputedStyle(element, null).getPropertyValue(prop);
-            }
-
-            return element.style[prop];
-        }
-
-        /**
          *
          * @param {HTMLElement} element
          * @param {Function}    resized
@@ -138,7 +122,7 @@
                 '</div>';
             element.appendChild(element.resizeSensor);
 
-            if (getComputedStyle(element, 'position') == 'static') {
+            if (element.resizeSensor.offsetParent !== element) {
                 element.style.position = 'relative';
             }
 


### PR DESCRIPTION
The aim of `getComputedStyle(element, 'position') == 'static'` is to detect that `element` is not "positioned".  
[`HTMLElement.offsetParent`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent) returns the nearest positioned element in the containment hierarchy.  
`element.resizeSensor.offsetParent !== element` mean that  `element` is not positioned.  
(see issue #164)
Right ?