### PR TITLE
Added check in queueQuery to prevent duplicate selectors

### DIFF
--- a/src/ElementQueries.js
+++ b/src/ElementQueries.js
@@ -177,7 +177,25 @@
             if (typeof(allQueries[mode]) == 'undefined') allQueries[mode] = {};
             if (typeof(allQueries[mode][property]) == 'undefined') allQueries[mode][property] = {};
             if (typeof(allQueries[mode][property][value]) == 'undefined') allQueries[mode][property][value] = selector;
-            else allQueries[mode][property][value] += ','+selector;
+            else if (typeof selector === 'string') {
+                // To build a regex from the selector we need to escape it first. The following function
+                // is given on MDN: https://developer.mozilla.org/en/docs/Web/JavaScript/Guide/Regular_Expressions
+                var escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+                // MATCHES full selector at the beginning, at the end, or somewhere inside the string.
+                // DOES NOT MATCH if it acts as a subselector or super selector.
+                var hasSelectorRegex = new RegExp(
+                    '(^' + escapedSelector + ',)|' +
+                    '(,' + escapedSelector + ',)|' +
+                    '(,' + escapedSelector + '$)|' +
+                    '(^' + escapedSelector + '$)'
+                );
+
+                // Add the selector only if it is not already present
+                if (!hasSelectorRegex.test(allQueries[mode][property][value])) {
+                    allQueries[mode][property][value] += ','+selector;
+                }
+            }
         }
 
         function getQuery() {


### PR DESCRIPTION
Duplicate selectors were being added to allQueries ad infinitum, so to prevent potentially huge concatenated strings from piling up in memory, I added a check in queueQuery. It uses a regex to check if the selector is already present in the string **in full**, so it does not prevent super selectors or sub selectors from being concatenated. 

I ran some tests manually to make sure everything checked out, but it would be good to turn those into unit tests at some point.

`
var css = '#selector .subselector'.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
var tester = new RegExp('(^' + css + ',)|(,' + css + ',)|(,' + css + '$)|(^' + css + '$)') 

### Should match single selector
tester.test('#selector .subselector')
// Expect: true
// Result: true

### Should match selector at the beginning
tester.test('#selector .subselector,.other-selector')
// Expect: true
// Result: ["#selector .subselector,", index: 0, input: "#selector .subselector,.other-selector"]

### Should match selector at the end
tester.test('.other-selector,#selector .subselector')
// Expect: true
// Result: true

### Should match selector inside string
tester.test('.other-selector,#selector .subselector,.yet-another-selector')
// Expect: true
// Result: true

### Should not match super selector at beginning
tester.test('#selector .subselector .subsubselector,.yet-another-selector')
// Expect: false
// Result: false

### Should not match sub selector at beginning
tester.test('#superselector #selector .subselector,.yet-another-selector')
// Expect: false
// Result: false

### Should not match super selector at end
tester.test('.other-selector,#selector .subselector .subsubselector')
// Expect: false
// Result: false

### Should not match sub selector at end
tester.test('.other-selector,#superselector #selector .subselector')
// Expect: false
// Result: false

### Should not match super selector inside string
tester.test('.other-selector,#selector .subselector .subsubselector,.yet-another-selector')
// Expect: false
// Result: false

### Should not match sub selector inside string
tester.test('.other-selector,#superselector #selector .subselector,.yet-another-selector')
// Expect: false
// Result: false
`

Let me know if there is anything missing.