### PR TITLE
Include imported styleSheets in rule extraction.

### DIFF
--- a/src/ElementQueries.js
+++ b/src/ElementQueries.js
@@ -367,6 +367,8 @@
                         }
                     } else if (4 === rules[i].type) {
                         readRules(rules[i].cssRules || rules[i].rules);
+                    } else if (3 === rules[i].type) {
+                        readRules(rules[i].styleSheet.cssRules);
                     }
                 }
             }


### PR DESCRIPTION
The imported rules were being ignored, I simply added a new condition to extract rules from those files, too.