### PR TITLE
Ignore InvalidAccessError when reading rules

### DIFF
--- a/src/ElementQueries.js
+++ b/src/ElementQueries.js
@@ -389,7 +389,7 @@
                 try {
                     readRules(document.styleSheets[i].cssRules || document.styleSheets[i].rules || document.styleSheets[i].cssText);
                 } catch(e) {
-                    if (e.name !== 'SecurityError') {
+                    if (e.name !== 'SecurityError' && e.name !== 'InvalidAccessError') {
                         throw e;
                     }
                 }


### PR DESCRIPTION
With Firefox (still true as of 56) and some versions of Edge and IE, `init` method throws an error "InvalidAccessError" when trying to read rules that come from a 3rd-party stylesheet.