### PR TITLE
Adding error check for InvalidAccessError

### DIFF
--- a/src/ElementQueries.js
+++ b/src/ElementQueries.js
@@ -389,7 +389,7 @@
                 try {
                     readRules(document.styleSheets[i].cssRules || document.styleSheets[i].rules || document.styleSheets[i].cssText);
                 } catch(e) {
-                    if (e.name !== 'SecurityError') {
+                    if (e.name !== 'SecurityError' && e.name !== 'InvalidAccessError') {
                         throw e;
                     }
                 }


### PR DESCRIPTION
This only happens with Firefox due to their security policy. 
Fix found in previous issue thread. https://github.com/marcj/css-element-queries/issues/117
Can confirm this was due to typekit being included in the project. 
It was quite annoying to debug in a build environment via es6 module loader (systemJS) so hopefully, this PR solves the issue for people. 
All credit to @jyrkij