### PR TITLE
Do not break when page it RTL

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -108,6 +108,7 @@
             element.resizedAttached.add(resized);
 
             element.resizeSensor = document.createElement('div');
+            element.resizeSensor.dir = 'ltr';
             element.resizeSensor.className = 'resize-sensor';
             var style = 'position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: hidden; z-index: -1; visibility: hidden;';
             var styleChild = 'position: absolute; left: 0; top: 0; transition: 0s;';


### PR DESCRIPTION
Greetings. We ran into an issue where the resize sensor was not behaving correctly when the dir of the html tag was set to `rtl` ( https://github.com/learningequality/kolibri/issues/1851). So a simple fix was to just set the dir of the resize sensor to `ltr` to prevent it from inheriting the dir. Thanks for this great library!