### PR TITLE
fix: sensor not working when element's width or height is 0

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -109,7 +109,7 @@
 
             element.resizeSensor = document.createElement('div');
             element.resizeSensor.className = 'resize-sensor';
-            var style = 'position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: hidden; z-index: -1; visibility: hidden;';
+            var style = 'position: absolute; left: -10px; top: -10px; right: 0; bottom: 0; overflow: hidden; z-index: -1; visibility: hidden;';
             var styleChild = 'position: absolute; left: 0; top: 0; transition: 0s;';
 
             element.resizeSensor.style.cssText = style;


### PR DESCRIPTION
when element's width or height is 0, `resizeSensor` get 0 as well, so it cannot trigger `scroll` event properly.

set `top` and `left` to `-10px`, make sure the width and height of `resizeSensor` has `10px` at least.

bug example: https://jsfiddle.net/lxjwlt/ko7ha6va/
after fixing: https://jsfiddle.net/lxjwlt/3hhownrp/