### PR TITLE
Fix ResizeSensor to fire when used in a CustomElement

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -166,8 +166,6 @@
                 shrink.scrollTop = 100000;
             };
 
-            reset();
-
             var onResized = function() {
                 rafId = 0;
 
@@ -204,6 +202,9 @@
 
             addEvent(expand, 'scroll', onScroll);
             addEvent(shrink, 'scroll', onScroll);
+            
+			// Fix for custom Elements
+			requestAnimationFrame(reset);
         }
 
         forEachElement(element, function(elem){


### PR DESCRIPTION
Calling Reset() just after initialization does not fire the 'scroll' events.
Instead, call it in the next frame. This also works with native elements and simple DOM.

Should fix #191 