### PR TITLE
Use resizeobserver when available

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -83,6 +83,9 @@
      * @constructor
      */
     var ResizeSensor = function(element, callback) {
+       
+        var observer;
+       
         /**
          *
          * @constructor
@@ -241,13 +244,38 @@
             // Fix for custom Elements
             requestAnimationFrame(reset);
         }
-
-        forEachElement(element, function(elem){
-            attachResizeEvent(elem, callback);
-        });
+         
+        if (typeof ResizeObserver != "undefined") {
+            observer = new ResizeObserver(function(entries){
+                for (var entry of entries) {
+                    callback.call(
+                        this,
+                        {
+                            width: entry.contentRect.width,
+                            height: entry.contentRect.height
+                        }
+                   );
+                }
+            });
+            if (element !== undefined) {
+                forEachElement(element, function(elem){
+                   observer.observe(elem);
+                });
+            }
+        }
+        else {
+            forEachElement(element, function(elem){
+                attachResizeEvent(elem, callback);
+            });
+        }
 
         this.detach = function(ev) {
-            ResizeSensor.detach(element, ev);
+            if (typeof ResizeObserver != "undefined") {
+               observer.unobserve(element);
+            }
+            else{
+                ResizeSensor.detach(element, ev);
+            }
         };
 
         this.reset = function() {

--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -83,9 +83,9 @@
      * @constructor
      */
     var ResizeSensor = function(element, callback) {
-
+       
         var observer;
-
+       
         /**
          *
          * @constructor
@@ -161,44 +161,44 @@
             var lastWidth = size.width;
             var lastHeight = size.height;
             var initialHiddenCheck = true, resetRAF_id;
-
-
+            
+            
             var resetExpandShrink_ = function () {
-              expandChild.style.width = '100000px';
-              expandChild.style.height = '100000px';
-
-              expand.scrollLeft = 100000;
-              expand.scrollTop = 100000;
-
-              shrink.scrollLeft = 100000;
-              shrink.scrollTop = 100000;
-           };
+		        expandChild.style.width = '100000px';
+		        expandChild.style.height = '100000px';
+		
+		        expand.scrollLeft = 100000;
+		        expand.scrollTop = 100000;
+		
+		        shrink.scrollLeft = 100000;
+		        shrink.scrollTop = 100000;
+	        };
             var reset = function() {
-               // Check if element is hidden
-               if (initialHiddenCheck){
-                  if (!expand.scrollTop && !expand.scrollLeft) {
+            	// Check if element is hidden
+            	if (initialHiddenCheck){
+            		if (!expand.scrollTop && !expand.scrollLeft) {
 
-                     // reset
-                     resetExpandShrink_();
+            			// reset
+			            resetExpandShrink_();
 
-                     // Check in next frame
-                     if (!resetRAF_id){
-                        resetRAF_id = requestAnimationFrame(function(){
-                           resetRAF_id = 0;
+			            // Check in next frame
+			            if (!resetRAF_id){
+			            	resetRAF_id = requestAnimationFrame(function(){
+					            resetRAF_id = 0;
+					            
+			            		reset();
+				            });
+			            }
+            			
+			            return;
+		            }
+		            // Stop checking
+		            else{
+			            initialHiddenCheck = false;
+		            }
+	            }
 
-                           reset();
-                        });
-                     }
-
-                     return;
-                  }
-                  // Stop checking
-                  else{
-                     initialHiddenCheck = false;
-                  }
-               }
-
-               resetExpandShrink_();
+	            resetExpandShrink_();
             };
             element.resizeSensor.resetSensor = reset;
 
@@ -240,11 +240,11 @@
 
             addEvent(expand, 'scroll', onScroll);
             addEvent(shrink, 'scroll', onScroll);
-
+            
             // Fix for custom Elements
             requestAnimationFrame(reset);
         }
-
+         
         if (typeof ResizeObserver != "undefined") {
             observer = new ResizeObserver(function(element){
                 forEachElement(element, function (elem) {

--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -83,9 +83,9 @@
      * @constructor
      */
     var ResizeSensor = function(element, callback) {
-       
+
         var observer;
-       
+
         /**
          *
          * @constructor
@@ -161,44 +161,44 @@
             var lastWidth = size.width;
             var lastHeight = size.height;
             var initialHiddenCheck = true, resetRAF_id;
-            
-            
+
+
             var resetExpandShrink_ = function () {
-		        expandChild.style.width = '100000px';
-		        expandChild.style.height = '100000px';
-		
-		        expand.scrollLeft = 100000;
-		        expand.scrollTop = 100000;
-		
-		        shrink.scrollLeft = 100000;
-		        shrink.scrollTop = 100000;
-	        };
+              expandChild.style.width = '100000px';
+              expandChild.style.height = '100000px';
+
+              expand.scrollLeft = 100000;
+              expand.scrollTop = 100000;
+
+              shrink.scrollLeft = 100000;
+              shrink.scrollTop = 100000;
+           };
             var reset = function() {
-            	// Check if element is hidden
-            	if (initialHiddenCheck){
-            		if (!expand.scrollTop && !expand.scrollLeft) {
+               // Check if element is hidden
+               if (initialHiddenCheck){
+                  if (!expand.scrollTop && !expand.scrollLeft) {
 
-            			// reset
-			            resetExpandShrink_();
+                     // reset
+                     resetExpandShrink_();
 
-			            // Check in next frame
-			            if (!resetRAF_id){
-			            	resetRAF_id = requestAnimationFrame(function(){
-					            resetRAF_id = 0;
-					            
-			            		reset();
-				            });
-			            }
-            			
-			            return;
-		            }
-		            // Stop checking
-		            else{
-			            initialHiddenCheck = false;
-		            }
-	            }
+                     // Check in next frame
+                     if (!resetRAF_id){
+                        resetRAF_id = requestAnimationFrame(function(){
+                           resetRAF_id = 0;
 
-	            resetExpandShrink_();
+                           reset();
+                        });
+                     }
+
+                     return;
+                  }
+                  // Stop checking
+                  else{
+                     initialHiddenCheck = false;
+                  }
+               }
+
+               resetExpandShrink_();
             };
             element.resizeSensor.resetSensor = reset;
 
@@ -240,22 +240,22 @@
 
             addEvent(expand, 'scroll', onScroll);
             addEvent(shrink, 'scroll', onScroll);
-            
+
             // Fix for custom Elements
             requestAnimationFrame(reset);
         }
-         
+
         if (typeof ResizeObserver != "undefined") {
-            observer = new ResizeObserver(function(entries){
-                for (var entry of entries) {
+            observer = new ResizeObserver(function(element){
+                forEachElement(element, function (elem) {
                     callback.call(
                         this,
                         {
-                            width: entry.contentRect.width,
-                            height: entry.contentRect.height
+                            width: elem.contentRect.width,
+                            height: elem.contentRect.height
                         }
                    );
-                }
+                });
             });
             if (element !== undefined) {
                 forEachElement(element, function(elem){

--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -164,41 +164,41 @@
             
             
             var resetExpandShrink_ = function () {
-		        expandChild.style.width = '100000px';
-		        expandChild.style.height = '100000px';
-		
-		        expand.scrollLeft = 100000;
-		        expand.scrollTop = 100000;
-		
-		        shrink.scrollLeft = 100000;
-		        shrink.scrollTop = 100000;
-	        };
+                expandChild.style.width = '100000px';
+                expandChild.style.height = '100000px';
+        
+                expand.scrollLeft = 100000;
+                expand.scrollTop = 100000;
+        
+                shrink.scrollLeft = 100000;
+                shrink.scrollTop = 100000;
+            };
             var reset = function() {
-            	// Check if element is hidden
-            	if (initialHiddenCheck){
-            		if (!expand.scrollTop && !expand.scrollLeft) {
+                // Check if element is hidden
+                if (initialHiddenCheck){
+                    if (!expand.scrollTop && !expand.scrollLeft) {
 
-            			// reset
-			            resetExpandShrink_();
+                        // reset
+                        resetExpandShrink_();
 
-			            // Check in next frame
-			            if (!resetRAF_id){
-			            	resetRAF_id = requestAnimationFrame(function(){
-					            resetRAF_id = 0;
-					            
-			            		reset();
-				            });
-			            }
-            			
-			            return;
-		            }
-		            // Stop checking
-		            else{
-			            initialHiddenCheck = false;
-		            }
-	            }
+                        // Check in next frame
+                        if (!resetRAF_id){
+                            resetRAF_id = requestAnimationFrame(function(){
+                                resetRAF_id = 0;
+                                
+                                reset();
+                            });
+                        }
+                        
+                        return;
+                    }
+                    // Stop checking
+                    else{
+                        initialHiddenCheck = false;
+                    }
+                }
 
-	            resetExpandShrink_();
+                resetExpandShrink_();
             };
             element.resizeSensor.resetSensor = reset;
 

--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -163,7 +163,7 @@
             var initialHiddenCheck = true, resetRAF_id;
             
             
-            var resetExpandShrink_ = function () {
+            var resetExpandShrink = function () {
                 expandChild.style.width = '100000px';
                 expandChild.style.height = '100000px';
         
@@ -173,13 +173,14 @@
                 shrink.scrollLeft = 100000;
                 shrink.scrollTop = 100000;
             };
+
             var reset = function() {
                 // Check if element is hidden
-                if (initialHiddenCheck){
+                if (initialHiddenCheck) {
                     if (!expand.scrollTop && !expand.scrollLeft) {
 
                         // reset
-                        resetExpandShrink_();
+                        resetExpandShrink();
 
                         // Check in next frame
                         if (!resetRAF_id){
@@ -191,14 +192,13 @@
                         }
                         
                         return;
-                    }
-                    // Stop checking
-                    else{
+                    } else {
+                        // Stop checking
                         initialHiddenCheck = false;
                     }
                 }
 
-                resetExpandShrink_();
+                resetExpandShrink();
             };
             element.resizeSensor.resetSensor = reset;
 
@@ -211,11 +211,7 @@
                 lastHeight = size.height;
 
                 if (element.resizedAttached) {
-                    element.resizedAttached.call(
-                    {
-                        width: lastWidth,
-                        height: lastHeight
-                    });
+                    element.resizedAttached.call(size);
                 }
             };
 
@@ -245,7 +241,7 @@
             requestAnimationFrame(reset);
         }
          
-        if (typeof ResizeObserver != "undefined") {
+        if (typeof ResizeObserver !== "undefined") {
             observer = new ResizeObserver(function(element){
                 forEachElement(element, function (elem) {
                     callback.call(
@@ -273,7 +269,7 @@
             if (typeof ResizeObserver != "undefined") {
                observer.unobserve(element);
             }
-            else{
+            else {
                 ResizeSensor.detach(element, ev);
             }
         };

--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -94,9 +94,9 @@
             };
 
             var i, j;
-            this.call = function() {
+            this.call = function(sizeInfo) {
                 for (i = 0, j = q.length; i < j; i++) {
-                    q[i].call();
+                    q[i].call(this, sizeInfo);
                 }
             };
 
@@ -190,7 +190,11 @@
                 lastHeight = newHeight;
 
                 if (element.resizedAttached) {
-                    element.resizedAttached.call();
+                    element.resizedAttached.call(
+                    {
+                        width: lastWidth,
+                        height: lastHeight
+                    });
                 }
             };
 

--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -152,32 +152,50 @@
             var expand = element.resizeSensor.childNodes[0];
             var expandChild = expand.childNodes[0];
             var shrink = element.resizeSensor.childNodes[1];
-            var dirty, rafId, newWidth, newHeight;
+
+            var dirty, rafId;
             var size = getElementSize(element);
             var lastWidth = size.width;
             var lastHeight = size.height;
-
+            var initialHiddenCheck = true, resetRAF_id;
+            
+            
+            var resetExpandShrink_ = function () {
+		        expandChild.style.width = '100000px';
+		        expandChild.style.height = '100000px';
+		
+		        expand.scrollLeft = 100000;
+		        expand.scrollTop = 100000;
+		
+		        shrink.scrollLeft = 100000;
+		        shrink.scrollTop = 100000;
+	        };
             var reset = function() {
-                //set display to block, necessary otherwise hidden elements won't ever work
-                var invisible = element.offsetWidth === 0 && element.offsetHeight === 0;
+            	// Check if element is hidden
+            	if (initialHiddenCheck){
+            		if (!expand.scrollTop && !expand.scrollLeft) {
 
-                if (invisible) {
-                    var saveDisplay = element.style.display;
-                    element.style.display = 'block';
-                }
+            			// reset
+			            resetExpandShrink_();
 
-                expandChild.style.width = '100000px';
-                expandChild.style.height = '100000px';
+			            // Check in next frame
+			            if (!resetRAF_id){
+			            	resetRAF_id = requestAnimationFrame(function(){
+					            resetRAF_id = 0;
+					            
+			            		reset();
+				            });
+			            }
+            			
+			            return;
+		            }
+		            // Stop checking
+		            else{
+			            initialHiddenCheck = false;
+		            }
+	            }
 
-                expand.scrollLeft = 100000;
-                expand.scrollTop = 100000;
-
-                shrink.scrollLeft = 100000;
-                shrink.scrollTop = 100000;
-
-                if (invisible) {
-                    element.style.display = saveDisplay;
-                }
+	            resetExpandShrink_();
             };
             element.resizeSensor.resetSensor = reset;
 
@@ -186,8 +204,8 @@
 
                 if (!dirty) return;
 
-                lastWidth = newWidth;
-                lastHeight = newHeight;
+                lastWidth = size.width;
+                lastHeight = size.height;
 
                 if (element.resizedAttached) {
                     element.resizedAttached.call(
@@ -199,10 +217,8 @@
             };
 
             var onScroll = function() {
-                var size = getElementSize(element);
-                var newWidth = size.width;
-                var newHeight = size.height;
-                dirty = newWidth != lastWidth || newHeight != lastHeight;
+                size = getElementSize(element);
+                dirty = size.width !== lastWidth || size.height !== lastHeight;
 
                 if (dirty && !rafId) {
                     rafId = requestAnimationFrame(onResized);
@@ -222,8 +238,8 @@
             addEvent(expand, 'scroll', onScroll);
             addEvent(shrink, 'scroll', onScroll);
             
-			// Fix for custom Elements
-			requestAnimationFrame(reset);
+            // Fix for custom Elements
+            requestAnimationFrame(reset);
         }
 
         forEachElement(element, function(elem){


### PR DESCRIPTION
This fixes #210 and #184 by using resizeobserver when available (afaik only chrome 64+ supports this at the moment)

The native resizeobserver is way faster than the current implementation.
This pr is based on #212 