### PR TITLE
Fix cross-domain cssRules access breaking code

### DIFF
--- a/src/ElementQueries.js
+++ b/src/ElementQueries.js
@@ -384,7 +384,9 @@
                     } else if (4 === rules[i].type) {
                         readRules(rules[i].cssRules || rules[i].rules);
                     } else if (3 === rules[i].type) {
-                        readRules(rules[i].styleSheet.cssRules);
+                        if(rules[i].styleSheet.hasOwnProperty("cssRules")) {
+                            readRules(rules[i].styleSheet.cssRules);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
When @import rule points to an other domain, accessing the style sheet with .cssRules will cause trouble on Chrome and Firefox (at least, haven't tested on other browsers). Firefox will raise a "Security error code: 1000" while Chrome will raise "Uncaught DOMException: Failed to read the 'cssRules' property from 'CSSStyleSheet': Cannot access rules" which (I d'ont know why) can't be caught with a regular try catch statement and will break the for loop and thus not parse the other rules if any. 

I had this problem while having a @import rule for google fonts. I fixed the issue by checking first if the property cssRules actually exist.