### PR TITLE
Fixed ResizeObserver detach error

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -267,7 +267,9 @@
 
         this.detach = function(ev) {
             if (typeof ResizeObserver != "undefined") {
-               observer.unobserve(element);
+                forEachElement(element, function(elem){
+                    observer.unobserve(elem);
+                });
             }
             else {
                 ResizeSensor.detach(element, ev);


### PR DESCRIPTION
Fixes error on detach: Uncaught TypeError: Failed to execute 'unobserve'
on 'ResizeObserver': parameter 1 is not of type 'Element'.