### PR TITLE
Fix animation-name check for old browsers

### DIFF
--- a/src/ElementQueries.js
+++ b/src/ElementQueries.js
@@ -409,9 +409,11 @@
 
             document.body.addEventListener(animationStart, function (e) {
                 var element = e.target;
-                var styles = window.getComputedStyle(element, null);
+                var styles = element && window.getComputedStyle(element, null);
+                var animationName = styles && styles.getPropertyValue('animation-name');
+                var requiresSetup = animationName && (-1 !== animationName.indexOf('element-queries'));
 
-                if (-1 !== styles.getPropertyValue('animation-name').indexOf('element-queries')) {
+                if (requiresSetup) {
                     element.elementQueriesSensor = new ResizeSensor(element, function () {
                         if (element.elementQueriesSetupInformation) {
                             element.elementQueriesSetupInformation.call();


### PR DESCRIPTION
According to a bug tracker of a developing app, old browsers like Safari of IOS8 or Chrome of Android5 could return `null` instead of requested style property. This patch brings additional checks.

Screenshot from our bug tracer:
![old-devices](https://user-images.githubusercontent.com/6743076/45488633-aa841780-b76a-11e8-812a-f533edec6e6b.png)

