### PR TITLE
Fixing to work with more recent versions of TypeScript

### DIFF
--- a/src/ResizeSensor.d.ts
+++ b/src/ResizeSensor.d.ts
@@ -3,4 +3,4 @@ declare class ResizeSensor {
     detach(callback: Function): void;
 }
 
-export = ResizeSensor;
+export default ResizeSensor;


### PR DESCRIPTION
Without this change I get this error from TypeScript:

```
Module '"node_modules/css-element-queries/src/ResizeSensor"' has no default export.

24 import ResizeSensor from "css-element-queries/src/ResizeSensor";
          ~~~~~~~~~~~~
```