### PR TITLE
added ResizeCallback to ResizeSensor.d.ts and added static functions …

### DIFF
--- a/src/ResizeSensor.d.ts
+++ b/src/ResizeSensor.d.ts
@@ -1,7 +1,12 @@
+export declare type ResizeCallback = (size: { width: number; height: number; }) => void;
+
 declare class ResizeSensor {
-    constructor(element: (Element | Element[]), callback: Function);
-    detach(callback: Function): void;
-    reset(element: Element | Element[]): void;
+    constructor(element: Element | Element[], callback: ResizeCallback);
+    detach(callback: ResizeCallback): void;
+    reset(): void;
+
+    static detach(element: Element | Element[], callback: ResizeCallback): void;
+    static reset(element: Element | Element[]): void;
 }
 
 export default ResizeSensor;


### PR DESCRIPTION
…to ResizeSensor class

This adds a ResizeCallback type instead of Function and adds the static detach/reset functions to ResizeSensor.

This allows the following:

```typescript
const callback: ResizeCallback = (size) => {
  console.log(size.width); // size.width is a number
  console.log(size.height); // size.height is a number
};

const sensor = new ResizeSensor(element, callback);
ResizeSensor.detach(element, callback); // type checked args
ResizeSensor.reset(element); // type checked args
sensor.detach(callback); // type checked arg
sensor.reset(); // type checked
```