### PR TITLE
Make the MutationObserver of ResizeSensor compatible with new Chrome version

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -278,13 +278,14 @@
     if (typeof MutationObserver !== "undefined") {
         var observer = new MutationObserver(function (mutations) {
             for (var i in mutations) {
-                var items = mutations[i].addedNodes;
-                for (var j = 0; j < items.length; j++) {
-                    if (items[j].resizeSensor) {
-                        ResizeSensor.reset(items[j]);
+                if (mutations.hasOwnProperty(i)) {
+                    var items = mutations[i].addedNodes;
+                    for (var j = 0; j < items.length; j++) {
+                        if (items[j].resizeSensor) {
+                            ResizeSensor.reset(items[j]);
+                        }
                     }
                 }
-
             }
         });
 


### PR DESCRIPTION
The for-in loop over the `NodeList` now goes through the prototype chain, so we check `hasOwnProperty` first.

Otherwise, we get this cryptic error:
```
Uncaught TypeError: Cannot read property 'length' of undefined
    at MutationObserver.<anonymous> (ResizeSensor.js:282)
```
