### PR TITLE
Rules on elements in different nestings are mostly ignored

### DIFF
--- a/src/ElementQueries.js
+++ b/src/ElementQueries.js
@@ -188,6 +188,7 @@
          * @param {String} value
          */
         function queueQuery(selector, mode, property, value) {
+            selector = selector.split(' ').slice(-1)[0]
             if (typeof(allQueries[selector]) === 'undefined') {
                 allQueries[selector] = [];
                 // add animation to trigger animationstart event, so we know exactly when a element appears in the DOM


### PR DESCRIPTION
In the current implementation problems arise when there are multiple rules defined on the same element but with different selectors. For example:

```
body #element-to-resize[max-width~="700px"] {
   color: red;
}

#element-to-resize[max-width~="900px"] {
  color: blue;
}
```
This will result in following `allQueries` object: 
```
{
  body #element-to-resize: [{
    mode: "max", property: "width", value: "700px"
  }],
  #element-to-resize: [{
    mode: "max", property: "width", value: "900px"
  }]
}
```

Because of limitation to not check the whole `allQueries` object but only the entries which match the current "id" (which is basically the strongest selector), the second breakpoint is not applied. 

To fix this, this PR cuts the selector down to the last elements, which is the identifier of the resized element. This is enough as the CSS handles the rest all by itself. So for the above example the following `allQueries` object emerges:

```
{
  #element-to-resize: [{
    mode: "max", property: "width", value: "700px"
  }, 
  {
    mode: "max", property: "width", value: "900px"
  }]
}
```

I am aware that this is only a hotfix with edge cases left out. However it catches most cases.