### PR TITLE
feat(typings): export ElementQueries typings

### DIFF
--- a/css-element-queries.d.ts
+++ b/css-element-queries.d.ts
@@ -1,1 +1,2 @@
 export { ResizeSensor, ResizeSensorCallback } from "./src/ResizeSensor";
+export { ElementQueries } from './src/ElementQueries';

--- a/src/ElementQueries.d.ts
+++ b/src/ElementQueries.d.ts
@@ -1,0 +1,14 @@
+export declare class ElementQueries {
+  /**
+   * Attaches to DOMLoadContent
+   */
+  static listen(): void;
+
+  /**
+   * Parses all available CSS and attach ResizeSensor to those elements which have rules attached.
+   * Make sure this is called after 'load' event, because CSS files are not ready when domReady is fired.
+   */
+  static init(): void;
+}
+
+export default ElementQueries;


### PR DESCRIPTION
Add the typing of ElementQueries

This allows to use this in ts :
```
import { ElementQueries } from 'css-element-queries';
...
ElementQueries.listen();
ElementQueries.init();
```
 
