### PR TITLE
Add support of sticky position on ResizeSensor

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -195,7 +195,7 @@
 
             var computedStyle = window.getComputedStyle(element);
             var position = computedStyle ? computedStyle.getPropertyValue('position') : null;
-            if ('absolute' !== position && 'relative' !== position && 'fixed' !== position) {
+            if ('absolute' !== position && 'relative' !== position && 'fixed' !== position && 'sticky' !== position) {
                 element.style.position = 'relative';
             }
 


### PR DESCRIPTION
Short fix to avoid ResizeSensor replacing sticky position by relative on watched element.