### PR TITLE
Fixed check for canceling last animation frame for invisible check

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -305,7 +305,7 @@
 
         this.detach = function(ev) {
             // clean up the unfinished animation frame to prevent a potential endless requestAnimationFrame of reset
-            if (!lastAnimationFrameForInvisibleCheck) {
+            if (lastAnimationFrameForInvisibleCheck) {
                 cancelAnimationFrame(lastAnimationFrameForInvisibleCheck);
                 lastAnimationFrameForInvisibleCheck = 0;
             }


### PR DESCRIPTION
Fixed check for clearing the last animation frame. The last animation frame should be cleared if it exists.