### PR TITLE
FIX: t.resizeSensor.resetSensor is not a function JS error

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -313,13 +313,19 @@
         };
 
         this.reset = function() {
-            element.resizeSensor.resetSensor();
+            //To prevent invoking element.resizeSensor.resetSensor if it's undefined
+            if (element.resizeSensor.resetSensor) {
+                element.resizeSensor.resetSensor();
+            }
         };
     };
 
     ResizeSensor.reset = function(element) {
         forEachElement(element, function(elem){
-            elem.resizeSensor.resetSensor();
+            //To prevent invoking element.resizeSensor.resetSensor if it's undefined
+            if (element.resizeSensor.resetSensor) {
+                elem.resizeSensor.resetSensor();
+            }
         });
     };
 


### PR DESCRIPTION
When using libraries that have css-element-queries as dependency, this JS error occurs. (Please see the screenshot) In my case, I use amcharts 4 and ember-table libraries in my ember application The JS error refers to `t.resizeSensor.resetSensor` is not a function.  `t.resizeSensor.resetSensor` seems to be undefined when it is invoked. To prevent this error, I added if condition to invoke only `t.resizeSensor.resetSensor` is not undefined.

<img width="1320" alt="Screen Shot 2020-04-01 at 10 06 57 AM" src="https://user-images.githubusercontent.com/5659090/78279098-0943ea00-74e5-11ea-84e4-d95e560875ff.png">

