### PR TITLE
fix: correct types declarations align to source code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+tab_width = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+yarn.lock
+package-lock.json

--- a/css-element-queries.d.ts
+++ b/css-element-queries.d.ts
@@ -1,2 +1,4 @@
-export { ResizeSensor, ResizeSensorCallback, Size } from "./src/ResizeSensor";
-export { ElementQueries } from './src/ElementQueries';
+import * as ResizeSensor from "./src/ResizeSensor";
+import * as ElementQueries from "./src/ElementQueries";
+
+export { ResizeSensor, ElementQueries };

--- a/src/ElementQueries.d.ts
+++ b/src/ElementQueries.d.ts
@@ -1,14 +1,18 @@
-export declare class ElementQueries {
-  /**
-   * Attaches to DOMLoadContent
-   */
-  static listen(): void;
+declare namespace ElementQueries {}
 
-  /**
-   * Parses all available CSS and attach ResizeSensor to those elements which have rules attached.
-   * Make sure this is called after 'load' event, because CSS files are not ready when domReady is fired.
-   */
-  static init(): void;
+declare class ElementQueries {
+    /**
+     * Attaches to DOMLoadContent
+     */
+    static listen(): void;
+
+    /**
+     * Parses all available CSS and attach ResizeSensor to those elements which have rules attached.
+     * Make sure this is called after 'load' event, because CSS files are not ready when domReady is fired.
+     */
+    static init(): void;
 }
 
-export default ElementQueries;
+export = ElementQueries;
+
+export as namespace ElementQueries;

--- a/src/ResizeSensor.d.ts
+++ b/src/ResizeSensor.d.ts
@@ -1,21 +1,26 @@
-export declare interface Size {
-    width: number;
-    height: number;
+declare namespace ResizeSensor {
+    interface Size {
+        width: number;
+        height: number;
+    }
+
+    type ResizeSensorCallback = (size: Size) => void;
 }
 
-export declare type ResizeSensorCallback = (size: Size) => void;
-
-export declare class ResizeSensor {
+declare class ResizeSensor {
     /**
      * Creates a new resize sensor on given elements. The provided callback is called max 1 times per requestAnimationFrame and
      * is called initially.
      */
-    constructor(element: Element | Element[], callback: ResizeSensorCallback);
+    constructor(
+        element: Element | Element[],
+        callback: ResizeSensor.ResizeSensorCallback
+    );
 
     /**
      * Removes the resize sensor, and stops listening to resize events.
      */
-    detach(callback?: ResizeSensorCallback): void;
+    detach(callback?: ResizeSensor.ResizeSensorCallback): void;
 
     /**
      * Resets the resize sensors, so for the next element resize is correctly detected. This is rare cases necessary
@@ -26,7 +31,10 @@ export declare class ResizeSensor {
     /**
      * Removes the resize sensor, and stops listening to resize events.
      */
-    static detach(element: Element | Element[], callback?: ResizeSensorCallback): void;
+    static detach(
+        element: Element | Element[],
+        callback?: ResizeSensor.ResizeSensorCallback
+    ): void;
 
     /**
      * Resets the resize sensors, so for the next element resize is correctly detected. This is rare cases necessary
@@ -35,4 +43,6 @@ export declare class ResizeSensor {
     static reset(element: Element | Element[]): void;
 }
 
-export default ResizeSensor;
+export = ResizeSensor;
+
+export as namespace ResizeSensor;

--- a/tests/mutation/app.ts
+++ b/tests/mutation/app.ts
@@ -1,5 +1,3 @@
-declare const ResizeSensor;
-
 const state: {
     dragged: Element
 } = {

--- a/tests/types/ElementQueries.ts
+++ b/tests/types/ElementQueries.ts
@@ -1,0 +1,4 @@
+import * as ElementQueries from "../../src/ElementQueries";
+
+ElementQueries.listen();
+ElementQueries.init();

--- a/tests/types/ResizeSensor.ts
+++ b/tests/types/ResizeSensor.ts
@@ -1,0 +1,18 @@
+import * as ResizeSensor from "../../src/ResizeSensor";
+
+const container = document.getElementById("container");
+
+const callback: ResizeSensor.ResizeSensorCallback = (
+  size: ResizeSensor.Size
+) => {
+  console.log(size);
+};
+
+const resizeSensor = new ResizeSensor(container, callback);
+resizeSensor.detach();
+resizeSensor.detach(callback);
+resizeSensor.reset();
+
+ResizeSensor.detach(container);
+ResizeSensor.detach(container, callback);
+ResizeSensor.reset(container);

--- a/tests/types/global.ts
+++ b/tests/types/global.ts
@@ -1,0 +1,11 @@
+ElementQueries.listen();
+ElementQueries.init();
+
+const container = document.getElementById("container");
+
+const resizeSensor = new ResizeSensor(container, () => {});
+resizeSensor.detach();
+resizeSensor.reset();
+
+ResizeSensor.detach(container);
+ResizeSensor.reset(container);

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -1,0 +1,13 @@
+import { ElementQueries, ResizeSensor } from "../..";
+
+ElementQueries.listen();
+ElementQueries.init();
+
+const container = document.getElementById("container");
+
+const resizeSensor = new ResizeSensor(container, () => {});
+resizeSensor.detach();
+resizeSensor.reset();
+
+ResizeSensor.detach(container);
+ResizeSensor.reset(container);


### PR DESCRIPTION
The following codes are actually incorrect but current types won't complain about it.

```ts
import { ElementQueries } from 'css-element-queries/src/ElementQueries'
import { ResizeSensor } from 'css-element-queries/src/ResizeSensor'
```

They should be like the following:


```ts
// by default
import * as ElementQueries from 'css-element-queries/src/ElementQueries'
import * as ResizeSensor from 'css-element-queries/src/ResizeSensor'

// or with `esModuleInterop: true` enabled
import ElementQueries from 'css-element-queries/src/ElementQueries'
import ResizeSensor from 'css-element-queries/src/ResizeSensor'
```
