### PR TITLE
fix: Allow ResizeSensor to be loaded in a Firefox extension

### DIFF
--- a/src/ResizeSensor.js
+++ b/src/ResizeSensor.js
@@ -25,7 +25,9 @@
         ? window
         : typeof self != 'undefined' && self.Math == Math
             ? self
-            : Function('return this')();
+            : typeof globalThis !== 'undefined'
+                ? globalThis
+                : Function('return this')();
     // Only used for the dirty checking, so the event callback count is limited to max 1 call per fps per sensor.
     // In combination with the event based resize sensor this saves cpu time, because the sensor is too fast and
     // would generate too many unnecessary events.


### PR DESCRIPTION
  Recent versions of the Firefox browser have a strict Content Security
  Policy in extension content scripts that disallows any direct or
  indirect string evaluation. Previously, the `Function('return this')`
  in ResizeSensor.js, used to obtain the true global window object,
  violated that security policy. This PR checks instead for the
  validity of the `globalThis` identifier, now provided in Firefox
  explicitly for the purpose that `Function('return this')` was being
  used for.

  As Mozilla will not sign extensions that patch third-party packages,
  without a change along these lines, no extension that directly or
  indirectly uses ResizeSensor could be created. Hence, it would be
  greatly appreciated for this small change to be merged and a new
  release made. Thanks for considering.